### PR TITLE
Feature template split

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,23 @@ sam deploy --guided --capabilities CAPABILITY_NAMED_IAM
 sam delete # delete stack
 ```
 If you want to use GUI, see [README_gui.md](./docs/README_gui.md)
+
+**For developer**, you can only deploy IAM Role and S3 for the first deploy.
+
+```shell
+# only initial deploy
+sam build -t ./template_s3iam.yaml
+sam deploy --guided --capabilities CAPABILITY_NAMED_IAM
+```
+
+```shell
+# skip deploy S3 and IAM Role
+sam build -t template_dev.yaml
+sam deploy --guided
+```
+> **Note**
+> Do not use `-t` in `sam deploy`
+> If you use, python library(boto3 and seleniumA) do not deploy with lambda and `No module name` Error occured.
 ******
 
 
@@ -128,3 +145,4 @@ python3 create_cookies.py --userid <docomo userid> --password <password> --bucke
 ```shell
 aws s3 cp cookies.pkl s3://cookie-for-iceman2 --acl private --profile=default
 ```
+

--- a/archive/app_local.py
+++ b/archive/app_local.py
@@ -1,20 +1,11 @@
 # coding: utf-8
 """
 Description: use cookies.pkl stored in S3 and login "https://www.ocn.ne.jp/" to push the ocn daily point button.
-Usage: This function is run by AWS EventBridge.
-
-Settings:
-- Lambda memory:3008 MB
-- Lambda timeout: 1 min.
-- Lambda layers: headless-chromium, chromedriver (created by ../../selenium_tools) and python libraries(created by ../../PackageLayers).
-- Lambda Environment variables: S3BucketCookie (S3 bucket name where cookies.pkl is stored.)
-
+Usage: AWS Lambada
 Author: Ryosuke D. Tomita
-Created: 2023/08/30
+Created: 2023/08/05
 """
 from selenium import webdriver
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.by import By
 import pickle
 import time
@@ -26,11 +17,11 @@ import boto3
 def lambda_handler(event, context):
     """
     実質的なmain関数
-    メモリ不足だとタイムアウトになったためとりあえず3008 MBを指定
     """
     # get environment variables
     url = "https://www.ocn.ne.jp/"
-    bucket_name = os.environ["BUCKET_NAME"]
+    #bucket_name = os.environ["S3BucketCookie"]
+    bucket_name = "cookie-for-iceman"
 
     # get cookies from s3
     cookies_file = _get_cookies_from_s3(bucket_name)
@@ -40,10 +31,9 @@ def lambda_handler(event, context):
     # driverにcookiewをセットしてログイン。
     driver.get(url)
     _set_cookies(driver, cookies_file)
-    driver.get(url) # reload
-
-    # ログイン後画面に移動するまで10秒まで待機する。
-    _wait_login(driver)
+    time.sleep(10)
+    driver.get(url)
+    time.sleep(10)
 
     # push daily point button.
     _get_daily_point(driver)
@@ -61,33 +51,33 @@ def _get_cookies_from_s3(bucket_name):
     cookies.pklがS3にない，もしくは空の場合にエラーを返す
     S3からcookies.pklを取得する
     """
-    s3 = boto3.resource('s3')
-    object_key = 'cookies.pkl'
-    bucket = s3.Bucket(bucket_name)
-    obj = bucket.Object(object_key)
-    response = obj.get()
-    with open('/tmp/temp_cookies.pkl', 'wb') as tf:
-        tf.write(response['Body'].read())
-    return '/tmp/temp_cookies.pkl'
+    #s3 = boto3.resource('s3')
+    #object_key = 'cookies.pkl'
+    #bucket = s3.Bucket(bucket_name)
+    #obj = bucket.Object(object_key)
+    #response = obj.get()
+    #with open('/tmp/temp_cookies.pkl', 'wb') as tf:
+    #    tf.write(response['Body'].read())
+    return '/home/tomita/ocn_daily_login/ocn_daily_login_aws_lambda/cookies.pkl'
 
 
 def _fetch_driver():
     """fetch_driver.
     ヘッドレスモードでドライバを取得する。
-    ドライバーはLambda Layersに配置されている。
     """
     options = webdriver.ChromeOptions()
-    # CloudFormationを使わない場合には/opt/headless/headless-chromiumを指定
-    options.binary_location = "/opt/python/headless-chromium"  
     # headlessモードのchromiumを指定
+    #options.binary_location = "/opt/headless/headless-chromium"
+    options.binary_location = "../../selenium_tools/headless/headless-chromium"
     options.add_argument("--headless")
     options.add_argument('--single-process')
     options.add_argument('--disable-dev-shm-usage')
     options.add_argument("--no-sandbox")
     # Layersに配置したものは/opt以下に展開される。
     driver = webdriver.Chrome(
-        # chromedriverのパスを指定。CloudFormationを使わない場合には/opt/headless/chromedriverを指定
-        executable_path="/opt/python/chromedriver",
+        # chromedriverのパスを指定
+        #executable_path="/opt/headless/chromedriver",
+        executable_path="../../selenium_tools/headless/chromedriver",
         options=options
     )
     return driver
@@ -102,19 +92,6 @@ def _set_cookies(driver, cookies_file):
             driver.add_cookie(c)
 
 
-def _wait_login(driver):
-    """_summary_
-    driverにcookieをセット後にログイン後ページに遷移したかを
-    ログイン後ページにしか存在しないログアウトボタンが表示されるまで待機する。
-
-    Args:
-        driver (_type_): _description_
-    """
-    wait = WebDriverWait(driver, 10)
-    wait.until(
-        EC.presence_of_element_located((By.XPATH, '//*[@id="pa14-pout-3d"]')))
-
-
 def _get_daily_point(driver):
     """get_daily_point.
     デイリーボタンを押す。
@@ -125,12 +102,13 @@ def _get_daily_point(driver):
     # selenium can only click viewing element, so scroll it.
     driver.execute_script("window.scrollTo(0, document.body.scrollHeight)")
     time.sleep(2)
+    #login_button = driver.find_element(By.XPATH, '//*[@id="pa14-pin-3d"]')
+    logout_button = driver.find_element(By.XPATH, '//*[@id="pa14-pout-3d"]')
 
-    point_button = driver.find_element(By.XPATH, '//*[@id="normalget"]/img') # chromeとchromiumのXPATHは同じ。
+    point_button = driver.find_element(By.XPATH, '//*[@id="normalget"]/img')
     point_button.click()
     time.sleep(3)
 
 
 if __name__ == "__main__":
     lambda_handler(None, None)
-

--- a/functions/push_ocn_daily_button/app.py
+++ b/functions/push_ocn_daily_button/app.py
@@ -74,6 +74,7 @@ def _get_cookies_from_s3(bucket_name):
 def _fetch_driver():
     """fetch_driver.
     ヘッドレスモードでドライバを取得する。
+    ドライバーはLambda Layersに配置されている。
     """
     options = webdriver.ChromeOptions()
     # CloudFormationを使わない場合には/opt/headless/headless-chromiumを指定

--- a/template.yaml
+++ b/template.yaml
@@ -1,4 +1,4 @@
-# !GetAttはテンプレート内でのARN等の参照に使う。
+# !GetAttはテンプレート内でのARN等の属性を参照する。
 # !Refはテンプレート内でのResourcesの参照に使う。
 # DependsOnには!Refを使わない。
 # CloudFomationはリソースの依存関係は!Refがついている場合には自動で解決される。
@@ -98,7 +98,7 @@ Resources:
       AccessControl: Private
 
   # EventBridge
-  # EventBridgeを定義するにあたってSheduleExpressionとEventPatternのどちらかは必要である。
+  # EventBridgeを定義するにあたってScheduleExpressionとEventPatternのどちらかは必要である。
   EventLaunch:
     Type: AWS::Events::Rule
     Properties:

--- a/template_dev.yaml
+++ b/template_dev.yaml
@@ -83,19 +83,11 @@ Resources:
       Environment:
         Variables:
           BUCKET_NAME: # S3BucketForCookieはtemplate内で定義されているため使えない
-            !Ref S3Bucket
+            !FindInMap [EnvironmentMap, !Ref Environment, S3BucketForCookie]
       Role: !GetAtt S3ReadonlyAccessRole.Arn
       Layers:
         # - !Ref PythonLibLayers
         - !Ref SeleniumDriverLayers
-
-  # S3
-  S3Bucket: # template内の環境変数でS3BucketForCookieやLambdaで定義した環境変数呼び出しキーBUCKET_NAMEと被らないようにする。
-    Type: AWS::S3::Bucket
-    # DeletionPolicy: Retain
-    Properties:
-      BucketName: !FindInMap [EnvironmentMap, !Ref Environment, S3BucketForCookie]
-      AccessControl: Private
 
   # EventBridge
   # EventBridgeを定義するにあたってSheduleExpressionとEventPatternのどちらかは必要である。

--- a/template_dev.yaml
+++ b/template_dev.yaml
@@ -1,11 +1,13 @@
-# !GetAttはテンプレート内でのARN等の参照に使う。
+# !GetAttはテンプレート内でのARN等の属性を参照する。
 # !Refはテンプレート内でのResourcesの参照に使う。
+# !Subは${hoge}のようにして環境変数に指定したhogeの内容を代入する。
 # DependsOnには!Refを使わない。
 # CloudFomationはリソースの依存関係は!Refがついている場合には自動で解決される。
+# deploy時に-tでテンプレートを指定するとlambdaに使用している外部ライブラリが登録されなくなる。指定しなければsam build時に生成されたものが使われるのでうまく行く。
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
 Description: >
-  get ocn daily point automatically.
+  get ocn daily point automatically (dev).
 Globals:
   Function:
     Timeout: 3
@@ -25,27 +27,12 @@ Mappings:
   EnvironmentMap:
     development:
       S3BucketForCookie: cookie-for-iceman2
+      S3ReadonlyAccessRole: for-lambda-s3-readonly-access-role
 
 
 Resources:
-  # Lambda用のIAMロール
-  S3ReadonlyAccessRole:
-    Type: AWS::IAM::Role
-    Properties:
-      RoleName: for-lambda-s3-readonly-access-role
-      # IAMロールがどのサービスまたはアカウントに対して信頼されるかを定義
-      AssumeRolePolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service: lambda.amazonaws.com
-            Action: sts:AssumeRole
-      ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess
-        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
-
   # Lambda Layers
+  # Lambda Layersは名前を指定するだけではだめそうなのでこちらに記載。
   SeleniumDriverLayers:
     Type: AWS::Serverless::LayerVersion
     DeletionPolicy: Retain # スタック削除時に削除しない
@@ -84,13 +71,15 @@ Resources:
         Variables:
           BUCKET_NAME: # S3BucketForCookieはtemplate内で定義されているため使えない
             !FindInMap [EnvironmentMap, !Ref Environment, S3BucketForCookie]
-      Role: !GetAtt S3ReadonlyAccessRole.Arn
+      Role:
+        Fn::Sub:
+          - arn:aws:iam::${AWS::AccountId}:role/${RoleName}
+          - RoleName: !FindInMap [EnvironmentMap, !Ref Environment, S3ReadonlyAccessRole]
       Layers:
-        # - !Ref PythonLibLayers
         - !Ref SeleniumDriverLayers
 
   # EventBridge
-  # EventBridgeを定義するにあたってSheduleExpressionとEventPatternのどちらかは必要である。
+  # EventBridgeを定義するにあたってScheduleExpressionとEventPatternのどちらかは必要である。
   EventLaunch:
     Type: AWS::Events::Rule
     Properties:

--- a/template_dev.yaml
+++ b/template_dev.yaml
@@ -27,12 +27,27 @@ Mappings:
   EnvironmentMap:
     development:
       S3BucketForCookie: cookie-for-iceman2
-      S3ReadonlyAccessRole: for-lambda-s3-readonly-access-role
 
 
 Resources:
+  # Lambda用のIAMロール
+  S3ReadonlyAccessRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: for-lambda-s3-readonly-access-role
+      # IAMロールがどのサービスまたはアカウントに対して信頼されるかを定義
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+
   # Lambda Layers
-  # Lambda Layersは名前を指定するだけではだめそうなのでこちらに記載。
   SeleniumDriverLayers:
     Type: AWS::Serverless::LayerVersion
     DeletionPolicy: Retain # スタック削除時に削除しない
@@ -71,15 +86,13 @@ Resources:
         Variables:
           BUCKET_NAME: # S3BucketForCookieはtemplate内で定義されているため使えない
             !FindInMap [EnvironmentMap, !Ref Environment, S3BucketForCookie]
-      Role:
-        Fn::Sub:
-          - arn:aws:iam::${AWS::AccountId}:role/${RoleName}
-          - RoleName: !FindInMap [EnvironmentMap, !Ref Environment, S3ReadonlyAccessRole]
+      Role: !GetAtt S3ReadonlyAccessRole.Arn
       Layers:
+        # - !Ref PythonLibLayers
         - !Ref SeleniumDriverLayers
 
   # EventBridge
-  # EventBridgeを定義するにあたってScheduleExpressionとEventPatternのどちらかは必要である。
+  # EventBridgeを定義するにあたってSheduleExpressionとEventPatternのどちらかは必要である。
   EventLaunch:
     Type: AWS::Events::Rule
     Properties:
@@ -102,3 +115,4 @@ Resources:
       FunctionName: !GetAtt PushOCNDailyPoint.Arn
       Principal: events.amazonaws.com
       SourceArn: !GetAtt EventLaunch.Arn
+

--- a/template_s3.yaml
+++ b/template_s3.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
 Description: >
-  get ocn daily point automatically.
+  get ocn daily point automatically (only s3).
 Globals:
   Function:
     Timeout: 3
@@ -28,23 +28,6 @@ Mappings:
 
 
 Resources:
-  # Lambda用のIAMロール
-  S3ReadonlyAccessRole:
-    Type: AWS::IAM::Role
-    Properties:
-      RoleName: for-lambda-s3-readonly-access-role
-      # IAMロールがどのサービスまたはアカウントに対して信頼されるかを定義
-      AssumeRolePolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service: lambda.amazonaws.com
-            Action: sts:AssumeRole
-      ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess
-        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
-
   # S3
   S3Bucket: # template内の環境変数でS3BucketForCookieやLambdaで定義した環境変数呼び出しキーBUCKET_NAMEと被らないようにする。
     Type: AWS::S3::Bucket

--- a/template_s3.yaml
+++ b/template_s3.yaml
@@ -1,0 +1,37 @@
+# !GetAttはテンプレート内でのARN等の参照に使う。
+# !Refはテンプレート内でのResourcesの参照に使う。
+# DependsOnには!Refを使わない。
+# CloudFomationはリソースの依存関係は!Refがついている場合には自動で解決される。
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+Description: >
+  get ocn daily point automatically.
+Globals:
+  Function:
+    Timeout: 3
+
+
+Parameters:
+  # 開発環境か本番環境かを切り替えるためのパラメータ
+  Environment:
+    Type: String
+    AllowedValues:
+      - development
+    Default: development
+
+
+# 環境変数の設定
+Mappings:
+  EnvironmentMap:
+    development:
+      S3BucketForCookie: cookie-for-iceman2
+
+
+Resources:
+  # S3
+  S3Bucket: # template内の環境変数でS3BucketForCookieやLambdaで定義した環境変数呼び出しキーBUCKET_NAMEと被らないようにする。
+    Type: AWS::S3::Bucket
+    # DeletionPolicy: Retain
+    Properties:
+      BucketName: !FindInMap [EnvironmentMap, !Ref Environment, S3BucketForCookie]
+      AccessControl: Private

--- a/template_s3iam.yaml
+++ b/template_s3iam.yaml
@@ -28,6 +28,23 @@ Mappings:
 
 
 Resources:
+  # Lambda用のIAMロール
+  S3ReadonlyAccessRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: for-lambda-s3-readonly-access-role
+      # IAMロールがどのサービスまたはアカウントに対して信頼されるかを定義
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+
   # S3
   S3Bucket: # template内の環境変数でS3BucketForCookieやLambdaで定義した環境変数呼び出しキーBUCKET_NAMEと被らないようにする。
     Type: AWS::S3::Bucket


### PR DESCRIPTION
### Change Description
CFnのスタックを削除する際に毎回S3バケットを空にするのが面倒なのでテンプレートを分けた。
ついでにIAMロールもテンプレートを分けようと思ったがブラウザ画面ではアタッチされているはずのIAMロールがlambda実行時に機能しないエラーが発生した(Issueに後述)ためIAMロールはテンプレートをわけなかった。

### Reference
- [Issue link](https://github.com/RyosukeDTomita/ocn_daily_login_aws_lambda/issues/16)
